### PR TITLE
Fix failing test

### DIFF
--- a/tests/php/test-class-plugin-base.php
+++ b/tests/php/test-class-plugin-base.php
@@ -41,14 +41,10 @@ class Test_Plugin_Base extends \WP_UnitTestCase {
 	 * @see Plugin_Base::is_wpcom_vip_prod()
 	 */
 	function test_is_wpcom_vip_prod() {
-		$this->assertFalse( $this->plugin->is_wpcom_vip_prod() );
-	}
-
-	/**
-	 * @see Plugin_Base::is_wpcom_vip_prod()
-	 */
-	function test_is_wpcom_vip_prod_true() {
-		define( 'WPCOM_IS_VIP_ENV', true );
-		$this->assertTrue( $this->plugin->is_wpcom_vip_prod() );
+		if ( ! defined( 'WPCOM_IS_VIP_ENV' ) ) {
+			$this->assertFalse( $this->plugin->is_wpcom_vip_prod() );
+			define( 'WPCOM_IS_VIP_ENV', true );
+		}
+		$this->assertEquals( WPCOM_IS_VIP_ENV, $this->plugin->is_wpcom_vip_prod() );
 	}
 }


### PR DESCRIPTION
When in the `vip-quickstart` environment the test would error out because the constant `WPCOM_IS_VIP_ENV` is already defined. It went unnoticed in the VVV environment that I added the test in originally.