### PR TITLE
Locate Plugin Dir URL Fix

### DIFF
--- a/php/class-plugin-base.php
+++ b/php/class-plugin-base.php
@@ -186,7 +186,7 @@ abstract class Plugin_Base {
 				}
 			}
 		}
-		return implode( $sep , $path );
+		return implode( $sep, $path );
 	}
 
 	/**

--- a/php/class-plugin-base.php
+++ b/php/class-plugin-base.php
@@ -152,10 +152,41 @@ abstract class Plugin_Base {
 		if ( 0 === $count ) {
 			throw new \Exception( "Class not located within a directory tree containing 'plugins': $file_name" );
 		}
-		$dir_url = content_url( trailingslashit( 'plugins/' . basename( $plugin_dir ) ) );
+
+		// Make sure that we can reliably get the relative path inside of the content directory.
+		$plugin_path = $this->relative_path( $plugin_dir, 'wp-content', \DIRECTORY_SEPARATOR );
+		if ( '' === $plugin_path ) {
+			throw new \Exception( 'Plugin dir is not inside of the `wp-content` directory' );
+		}
+
+		$dir_url = content_url( trailingslashit( $plugin_path ) );
 		$dir_path = $plugin_dir;
 		$dir_basename = basename( $plugin_dir );
 		return compact( 'dir_url', 'dir_path', 'dir_basename' );
+	}
+
+	/**
+	 * Relative Path
+	 *
+	 * Returns a relative path from a specified starting position of a full path
+	 *
+	 * @param string $path The full path to start with.
+	 * @param string $start The directory after which to start creating the relative path.
+	 * @param string $sep The directory seperator.
+	 *
+	 * @return string
+	 */
+	public function relative_path( $path, $start, $sep ) {
+		$path = explode( $sep, untrailingslashit( $path ) );
+		if ( count( $path ) > 0 ) {
+			foreach ( $path as $p ) {
+				array_shift( $path );
+				if ( $p === $start ) {
+					break;
+				}
+			}
+		}
+		return implode( $sep , $path );
 	}
 
 	/**

--- a/php/class-plugin-base.php
+++ b/php/class-plugin-base.php
@@ -152,17 +152,7 @@ abstract class Plugin_Base {
 		if ( 0 === $count ) {
 			throw new \Exception( "Class not located within a directory tree containing 'plugins': $file_name" );
 		}
-
-		// Make sure that we can reliably get the relative path inside of the content directory.
-		$content_dir = realpath( trailingslashit( WP_CONTENT_DIR ) );
-		if ( '/' !== \DIRECTORY_SEPARATOR ) {
-			$content_dir = str_replace( \DIRECTORY_SEPARATOR, '/', $content_dir ); // Windows compat.
-		}
-		if ( 0 !== strpos( $plugin_dir, $content_dir ) ) {
-			throw new \Exception( 'Plugin dir is not inside of WP_CONTENT_DIR' );
-		}
-		$content_sub_path = substr( $plugin_dir, strlen( $content_dir ) );
-		$dir_url = content_url( trailingslashit( $content_sub_path ) );
+		$dir_url = content_url( trailingslashit( 'plugins/' . basename( $plugin_dir ) ) );
 		$dir_path = $plugin_dir;
 		$dir_basename = basename( $plugin_dir );
 		return compact( 'dir_url', 'dir_path', 'dir_basename' );

--- a/tests/php/test-class-plugin-base.php
+++ b/tests/php/test-class-plugin-base.php
@@ -44,6 +44,16 @@ class Test_Plugin_Base extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test relative_path.
+	 *
+	 * @see Plugin_Base::relative_path()
+	 */
+	public function test_relative_path() {
+		$this->assertEquals( 'plugins/foo-bar', $this->plugin->relative_path( '/srv/www/wordpress-develop/src/wp-content/plugins/foo-bar', 'wp-content', '/' ) );
+		$this->assertEquals( 'themes/twentysixteen/plugins/foo-bar', $this->plugin->relative_path( '/srv/www/wordpress-develop/src/wp-content/themes/twentysixteen/plugins/foo-bar', 'wp-content', '/' ) );
+	}
+
+	/**
 	 * Tests for trigger_warning().
 	 *
 	 * @see Plugin_Base::trigger_warning()


### PR DESCRIPTION
* Updating the locate_plugin method to use the plugin directory name as the base for the dir_url
* This is required since when running tests, the WP_CONTENT_DIR is set to a different WordPress install (wordpress-develop on VVV) by WP-Dev-Lib's bootstrap than the current plugin's install and thus the tests throw an exception before they can  be run

@westonruter This removes what appears to be some significant functionality to figure out the url of the plugin. It also removes a check that the plugin resides in the wp-content directory. There were a few ways to go about fixing this bug and this is the way I chose. Happy to discuss alternatives and add additional checks.