### PR TITLE
Renamed the Test_Doc_hooks class and moved it to its own file

### DIFF
--- a/tests/php/test-class-doc-hooks.php
+++ b/tests/php/test-class-doc-hooks.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Test_Doc_hooks class.
+ *
+ * @package FooBar
+ */
+
+namespace FooBar;
+
+/**
+ * Test_Doc_hooks class.
+ */
+class Test_Doc_Hooks {
+
+	/**
+	 * Load this on the init action hook.
+	 *
+	 * @action init
+	 */
+	public function init_action() {}
+
+	/**
+	 * Load this on the the_content filter hook.
+	 *
+	 * @filter the_content
+	 *
+	 * @param string $content The content.
+	 * @return string
+	 */
+	public function the_content_filter( $content ) {
+		return $content;
+	}
+}

--- a/tests/php/test-class-plugin-base.php
+++ b/tests/php/test-class-plugin-base.php
@@ -87,7 +87,7 @@ class Test_Plugin_Base extends \WP_UnitTestCase {
 	 * @see Plugin_Base::add_doc_hooks()
 	 */
 	public function test_add_doc_hooks() {
-		$object = new Test_Doc_hooks();
+		$object = new Test_Doc_Hooks();
 		$this->assertFalse( has_action( 'init', array( $object, 'init_action' ) ) );
 		$this->assertFalse( has_action( 'the_content', array( $object, 'the_content_filter' ) ) );
 		$this->plugin->add_doc_hooks( $object );
@@ -128,7 +128,7 @@ class Test_Plugin_Base extends \WP_UnitTestCase {
 	 * @see Plugin_Base::remove_doc_hooks()
 	 */
 	public function test_remove_doc_hooks() {
-		$object = new Test_Doc_hooks();
+		$object = new Test_Doc_Hooks();
 		$this->plugin->add_doc_hooks( $object );
 		$this->assertEquals( 10, has_action( 'init', array( $object, 'init_action' ) ) );
 		$this->assertEquals( 10, has_action( 'the_content', array( $object, 'the_content_filter' ) ) );
@@ -137,29 +137,3 @@ class Test_Plugin_Base extends \WP_UnitTestCase {
 		$this->assertFalse( has_action( 'the_content', array( $object, 'the_content_filter' ) ) );
 	}
 }
-
-/**
- * Test_Doc_hooks class.
- */
-class Test_Doc_hooks {
-
-	/**
-	 * Load this on the init action hook.
-	 *
-	 * @action init
-	 */
-	public function init_action() {}
-
-	/**
-	 * Load this on the the_content filter hook.
-	 *
-	 * @filter the_content
-	 *
-	 * @param string $content The content.
-	 * @return string
-	 */
-	public function the_content_filter( $content ) {
-		return $content;
-	}
-}
-


### PR DESCRIPTION
Renamed the Test_Doc_hooks class per WP coding standards and moved it to its own file