### PR TITLE
Add missing postcss bare config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
@derekherman,

Another one. It seems that without at least a bare postcss config file, there is an error when importing a css file such as

```
ERROR in ./assets/src/block-editor/style.css
    Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
    ModuleBuildError: Module build failed (from ./node_modules/postcss-loader/src/index.js):
    Error: No PostCSS Config found in: /Users/davidlonjon/projects/xwp/wp-material-theming-plugin/assets/src/block-editor
....
```