### PR TITLE
Add postcss config so css-in-js can be compiled

### DIFF
--- a/assets/src/block-editor/edit.css
+++ b/assets/src/block-editor/edit.css
@@ -1,0 +1,1 @@
+/* Add the CSS code to this file. On running npm run dev, it will compile with build:js into assets/css/. */

--- a/assets/src/block-editor/index.js
+++ b/assets/src/block-editor/index.js
@@ -1,5 +1,10 @@
 // Add the JS code to this file. On running npm run dev, it will compile to assets/js/.
 
+/**
+ * Internal dependencies
+ */
+import './edit.css';
+
 export function add( to, howMuch ) {
 	return to + howMuch;
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@wordpress/dom-ready": "2.7.0",
     "@wordpress/eslint-plugin": "3.4.1",
     "@wordpress/i18n": "3.9.0",
+    "@wordpress/postcss-themes": "2.2.0",
     "@wordpress/scripts": "7.0.1",
     "@wordpress/server-side-render": "1.7.0",
     "@wordpress/url": "2.10.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,80 @@
+module.exports = {
+	plugins: [
+		require( '@wordpress/postcss-themes' )( {
+			defaults: {
+				primary: '#007cba',
+				secondary: '#11a0d2',
+				toggle: '#11a0d2',
+				button: '#007cba',
+				outlines: '#007cba',
+			},
+			themes: {
+				'admin-color-light': {
+					primary: '#007cba',
+					secondary: '#c75726',
+					toggle: '#11a0d2',
+					button: '#007cba',
+					outlines: '#007cba',
+				},
+				'admin-color-blue': {
+					primary: '#82b4cb',
+					secondary: '#d9ab59',
+					toggle: '#82b4cb',
+					button: '#d9ab59',
+					outlines: '#417e9B',
+				},
+				'admin-color-coffee': {
+					primary: '#c2a68c',
+					secondary: '#9fa47b',
+					toggle: '#c2a68c',
+					button: '#c2a68c',
+					outlines: '#59524c',
+				},
+				'admin-color-ectoplasm': {
+					primary: '#a7b656',
+					secondary: '#c77430',
+					toggle: '#a7b656',
+					button: '#a7b656',
+					outlines: '#523f6d',
+				},
+				'admin-color-midnight': {
+					primary: '#e14d43',
+					secondary: '#77a6b9',
+					toggle: '#77a6b9',
+					button: '#e14d43',
+					outlines: '#497b8d',
+				},
+				'admin-color-ocean': {
+					primary: '#a3b9a2',
+					secondary: '#a89d8a',
+					toggle: '#a3b9a2',
+					button: '#a3b9a2',
+					outlines: '#5e7d5e',
+				},
+				'admin-color-sunrise': {
+					primary: '#d1864a',
+					secondary: '#c8b03c',
+					toggle: '#c8b03c',
+					button: '#d1864a',
+					outlines: '#837425',
+				},
+			},
+		} ),
+		require( 'postcss-color-function' ),
+		require( 'postcss-import' ),
+		require( 'postcss-nested' ),
+		require( 'postcss-preset-env' )( {
+			stage: 0,
+			preserve: false, // Omit pre-polyfilled CSS.
+			features: {
+				'nesting-rules': false, // Uses postcss-nesting which doesn't behave like Sass.
+				'custom-properties': {
+					preserve: true, // Do not remove :root selector.
+				},
+			},
+			autoprefixer: {
+				grid: true,
+			},
+		} ),
+	],
+};


### PR DESCRIPTION
## Summary

Fixes bulid:js - now it correctly compiles the CSS imported in JS.

