### PR TITLE
URLs need forward slashes

### DIFF
--- a/php/class-plugin-base.php
+++ b/php/class-plugin-base.php
@@ -158,7 +158,7 @@ abstract class Plugin_Base {
 	public function locate_plugin() {
 		$file_name = $this->get_object_reflection()->getFileName();
 
-		// Windows compat.
+		// Convert to forward-slashes as needed for URLs.
 		if ( '/' !== \DIRECTORY_SEPARATOR ) {
 			// @codeCoverageIgnoreStart
 			$file_name = str_replace( \DIRECTORY_SEPARATOR, '/', $file_name );
@@ -166,7 +166,7 @@ abstract class Plugin_Base {
 		}
 
 		$plugin_dir  = dirname( dirname( $file_name ) );
-		$plugin_path = $this->relative_path( $plugin_dir, basename( content_url() ), \DIRECTORY_SEPARATOR );
+		$plugin_path = $this->relative_path( $plugin_dir, basename( content_url() ), '/' );
 
 		$dir_url      = content_url( trailingslashit( $plugin_path ) );
 		$dir_path     = $plugin_dir;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #205.

Per https://github.com/xwp/unsplash-wp/pull/201#issuecomment-667900579

> DIRECTORY_SEPARATOR is \ on windows, Ln:171 replaces the path so the DIRECTORY_SEPARATOR becomes /. But Ln:176 tries to split the path using DIRECTORY_SEPARATOR constant while the path has that value replaced with a /. The fix always splits the path using /.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/xwp/wp-foo-bar/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/xwp/wp-foo-bar/contributing.md#scripts).
- [x] My code follows the [Contributing Guidelines](https://github.com/xwp/wp-foo-bar/contributing.md) (updates are often made to the guidelines, check it out periodically).
