### PR TITLE
Fix WP phpunit library dependencies

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -5,6 +5,6 @@ MYSQL_USER=wordpress
 MYSQL_PASSWORD=wordpress
 
 # WordPress
-WP_VERSION=5.4
+WP_VERSION=5.8
 WP_DB_USER=wordpress
 WP_DB_PASSWORD=wordpress

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,10 +115,10 @@ jobs:
       php: "5.6"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer require --dev phpunit/phpunit ^5 --with-all-dependencies
+        - composer require --dev phpunit/phpunit ^5 --update-with-all-dependencies
 
     - name: PHP unit tests (5.6, WordPress 5.0)
       php: "5.6"
       env: WP_VERSION=5.0 DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer require --dev phpunit/phpunit ^5 --with-all-dependencies
+        - composer require --dev phpunit/phpunit ^5 --update-with-all-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ jobs:
         - echo "Running E2E tests with code coverage ..."
       script:
         - npm run env:start
-        - npm run wp -- curl --retry 30 --retry-delay 1 --retry-connrefused telnet://mysql:3306 --output /dev/null
+        - npm run wp -- bash -c "while ! nc -z mysql 3306; do sleep 1; done"
         - npm run wp -- wp core install --title=WordPress --admin_user=admin --admin_password=password --admin_email=admin@example.com --skip-email --url=http://localhost:8088 --quiet
         - npm run wp -- wp plugin activate foo-bar
         - npm run build:js
@@ -115,10 +115,12 @@ jobs:
       php: "5.6"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer require --dev phpunit/phpunit:^5 phpunit/phpcov:^3 --update-with-all-dependencies
+        - composer config platform.php false
+        - composer require --dev phpunit/phpunit:^5 phpunit/phpcov php-coveralls/php-coveralls --update-with-dependencies
 
     - name: PHP unit tests (5.6, WordPress 5.0)
       php: "5.6"
       env: WP_VERSION=5.0 DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer require --dev phpunit/phpunit:^5 phpunit/phpcov:^3 --update-with-all-dependencies
+        - composer config platform.php false
+        - composer require --dev phpunit/phpunit:^5 phpunit/phpcov php-coveralls/php-coveralls --update-with-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,22 +109,6 @@ jobs:
       php: "7.4"
       env: WP_VERSION=trunk DEV_LIB_ONLY=phpunit,composer
 
-    - name: PHP unit tests (7.3, WordPress latest)
-      php: "7.3"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
-
-    - name: PHP unit tests (7.2, WordPress latest)
-      php: "7.2"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
-
-    - name: PHP unit tests (7.1, WordPress latest)
-      php: "7.1"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
-
-    - name: PHP unit tests (7.0, WordPress latest)
-      php: "7.0"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
-
     - name: PHP unit tests (5.6, WordPress latest)
       php: "5.6"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ env:
 before_install:
   - nvm install
   - nvm use
-  - docker-compose pull
 
 install:
   - npm install
@@ -75,6 +74,7 @@ jobs:
       install:
         - sudo service mysql stop
         - npm install
+        - docker-compose pull
       before_script:
         - echo "Running E2E tests with code coverage ..."
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,10 +115,10 @@ jobs:
       php: "5.6"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer require --dev phpunit/phpunit ^5 --update-with-all-dependencies
+        - composer require --dev phpunit/phpunit:^5 phpunit/phpcov:^3 --update-with-all-dependencies
 
     - name: PHP unit tests (5.6, WordPress 5.0)
       php: "5.6"
       env: WP_VERSION=5.0 DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer require --dev phpunit/phpunit ^5 --update-with-all-dependencies
+        - composer require --dev phpunit/phpunit:^5 phpunit/phpcov:^3 --update-with-all-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
     - stage: lint
       name: Lint (PHP, JavaScript, and configuration files)
       php: "7.4"
-      env: WP_VERSION=latest DEV_LIB_ONLY=xmllint,phpsyntax
+      env: WP_VERSION=latest DEV_LIB_ONLY=xmllint,phpsyntax,composer
       script:
         - source "$DEV_LIB_PATH/travis.script.sh"
         - npm run lint
@@ -99,34 +99,34 @@ jobs:
 
     - name: PHP unit tests (7.4, WordPress latest, with code coverage)
       php: "7.4"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,coverage
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,coverage,composer
       before_script:
         - echo "Running PHP unit tests with code coverage ..."
 
     - name: PHP unit tests (7.4, WordPress trunk)
       php: "7.4"
-      env: WP_VERSION=trunk DEV_LIB_ONLY=phpunit
+      env: WP_VERSION=trunk DEV_LIB_ONLY=phpunit,composer
 
     - name: PHP unit tests (7.3, WordPress latest)
       php: "7.3"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
 
     - name: PHP unit tests (7.2, WordPress latest)
       php: "7.2"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
 
     - name: PHP unit tests (7.1, WordPress latest)
       php: "7.1"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
 
     - name: PHP unit tests (7.0, WordPress latest)
       php: "7.0"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
 
     - name: PHP unit tests (5.6, WordPress latest)
       php: "5.6"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
 
     - name: PHP unit tests (5.6, WordPress 5.0)
       php: "5.6"
-      env: WP_VERSION=5.0 DEV_LIB_ONLY=phpunit
+      env: WP_VERSION=5.0 DEV_LIB_ONLY=phpunit,composer

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,10 +114,10 @@ jobs:
       php: "5.6"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer require --dev phpunit/phpunit ^5
+        - composer require --dev phpunit/phpunit ^5 --with-all-dependencies
 
     - name: PHP unit tests (5.6, WordPress 5.0)
       php: "5.6"
       env: WP_VERSION=5.0 DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer require --dev phpunit/phpunit ^5
+        - composer require --dev phpunit/phpunit ^5 --with-all-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ branches:
 env:
   global:
     - COVERALLS_PARALLEL=true
+    # Ensure Xdebug v3 coverage reporting is available.
+    - XDEBUG_MODE=coverage
 
 before_install:
   - nvm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ jobs:
         - echo "Running E2E tests with code coverage ..."
       script:
         - npm run env:start
-        - npm run wp -- php -r "fsockopen( 'mysql', 3306, \\\$err_no, \\\$err_str, 30 );"
+        - npm run wp -- curl --retry 30 --retry-delay 1 --retry-connrefused telnet://mysql:3306 --output /dev/null
         - npm run wp -- wp core install --title=WordPress --admin_user=admin --admin_password=password --admin_email=admin@example.com --skip-email --url=http://localhost:8088 --quiet
         - npm run wp -- wp plugin activate foo-bar
         - npm run build:js

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,12 +115,12 @@ jobs:
       php: "5.6"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer config platform.php false
+        - composer config --unset platform.php
         - composer require --dev phpunit/phpunit:^5 phpunit/phpcov php-coveralls/php-coveralls --update-with-dependencies
 
     - name: PHP unit tests (5.6, WordPress 5.0)
       php: "5.6"
       env: WP_VERSION=5.0 DEV_LIB_ONLY=phpunit,composer
       before_script:
-        - composer config platform.php false
+        - composer config --unset platform.php
         - composer require --dev phpunit/phpunit:^5 phpunit/phpcov php-coveralls/php-coveralls --update-with-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
     - stage: test
       name: E2E tests with Docker (7.4, WordPress latest, with code coverage)
       php: "7.4"
-      env: NODE_ENV=e2e WP_VERSION=latest
+      env: NODE_ENV=e2e
       install:
         - sudo service mysql stop
         - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ env:
 before_install:
   - nvm install
   - nvm use
+  - docker-compose pull
 
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ jobs:
         - echo "Running E2E tests with code coverage ..."
       script:
         - npm run env:start
+        - npm run wp -- php -r "fsockopen( 'mysql', 3306, \\\$err_no, \\\$err_str, 30 );"
         - npm run wp -- wp core install --title=WordPress --admin_user=admin --admin_password=password --admin_email=admin@example.com --skip-email --url=http://localhost:8088 --quiet
         - npm run wp -- wp plugin activate foo-bar
         - npm run build:js

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,11 @@ jobs:
     - name: PHP unit tests (5.6, WordPress latest)
       php: "5.6"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,composer
+      before_script:
+        - composer require --dev phpunit/phpunit ^5
 
     - name: PHP unit tests (5.6, WordPress 5.0)
       php: "5.6"
       env: WP_VERSION=5.0 DEV_LIB_ONLY=phpunit,composer
+      before_script:
+        - composer require --dev phpunit/phpunit ^5

--- a/bin/local-dev/wordpress/Dockerfile
+++ b/bin/local-dev/wordpress/Dockerfile
@@ -4,6 +4,7 @@ FROM wordpress:${WP_VERSION}-php7.4-apache
 
 ENV NODE_VERSION 10.18.1
 ENV YARN_VERSION 1.21.1
+ENV XDEBUG_VERSION 2.9.8
 
 # Setup user.
 RUN groupadd --gid 1000 webserver \
@@ -90,5 +91,5 @@ RUN curl -s https://getcomposer.org/installer | php \
 COPY config/php/* /usr/local/etc/php/conf.d/
 
 # Setup xdebug.
-RUN pecl install xdebug; \
+RUN pecl install xdebug-${XDEBUG_VERSION}; \
 	docker-php-ext-enable xdebug;

--- a/bin/local-dev/wordpress/Dockerfile
+++ b/bin/local-dev/wordpress/Dockerfile
@@ -38,9 +38,8 @@ RUN buildDeps='xz-utils' \
     A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
     B9E2F5981AA6E0CD28160D9FF13993A75599653C \
   ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" ; \
   done \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -56,9 +55,8 @@ RUN set -ex \
   && for key in \
     6A010C5166006599AA17F08146C2130DFD2497F5 \
   ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" ; \
   done \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "slowprog/composer-copy-file": "@stable",
     "wp-coding-standards/wpcs": "@stable",
     "xwp/wordpress-tests-installer": "@stable",
-    "xwp/wp-dev-lib": "@stable"
+    "xwp/wp-dev-lib": "@stable",
+    "yoast/phpunit-polyfills": "^1.0"
   },
   "scripts": {
     "build": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "151e4aee9e160fa710eb9a952e56f1b3",
+    "content-hash": "cab471d33cce48f48ad0e9551439aa52",
     "packages": [],
     "packages-dev": [
         {
@@ -3333,6 +3333,69 @@
                 "wordpress"
             ],
             "time": "2020-10-16T04:03:40+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "f014fb21c2b0038fd329515d59025af42fb98715"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/f014fb21c2b0038fd329515d59025af42fb98715",
+                "reference": "f014fb21c2b0038fd329515d59025af42fb98715",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-08-09T16:28:08+00:00"
         }
     ],
     "aliases": [],
@@ -3355,5 +3418,6 @@
     "platform-overrides": {
         "php": "7.4.2",
         "ext-filter": "7.1"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
 
   wordpress:
-    image: ghcr.io/xwp/wp-foo-bar-wordpress:${WP_VERSION:-latest}
+    image: ghcr.io/xwp/wp-foo-bar-wordpress:${WP_VERSION}
     build:
       context: ./bin/local-dev/wordpress
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,10 @@ services:
       - mysql
       - wordpress
     command: tail -f /dev/null
+    environment:
+      WORDPRESS_DEBUG: 1
+      WORDPRESS_DB_USER: ${WP_DB_USER}
+      WORDPRESS_DB_PASSWORD: ${WP_DB_PASSWORD}
 
   mailhog:
     image: mailhog/mailhog

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
 
   wordpress:
-    image: ghcr.io/xwp/wp-foo-bar-wordpress:${WP_VERSION}
+    image: ghcr.io/xwp/wp-foo-bar-wordpress:${WP_VERSION:-latest}
     build:
       context: ./bin/local-dev/wordpress
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
 
   wordpress:
+    image: ghcr.io/xwp/wp-foo-bar-wordpress:${WP_VERSION}
     build:
       context: ./bin/local-dev/wordpress
       args:

--- a/tests/e2e/utils/open-global-block-inserter.js
+++ b/tests/e2e/utils/open-global-block-inserter.js
@@ -28,7 +28,5 @@ async function isGlobalInserterOpen() {
 }
 
 async function toggleGlobalBlockInserter() {
-	await page.click(
-		'.edit-post-header-toolbar__inserter-toggle'
-	);
+	await page.click( '.edit-post-header-toolbar__inserter-toggle' );
 }

--- a/tests/e2e/utils/open-global-block-inserter.js
+++ b/tests/e2e/utils/open-global-block-inserter.js
@@ -22,13 +22,13 @@ export async function closeGlobalBlockInserter() {
 async function isGlobalInserterOpen() {
 	return await page.evaluate( () => {
 		return !! document.querySelector(
-			'.edit-post-header [aria-label="Add block"].is-pressed, .edit-site-header [aria-label="Add block"].is-pressed'
+			'.edit-post-header-toolbar__inserter-toggle.is-pressed'
 		);
 	} );
 }
 
 async function toggleGlobalBlockInserter() {
 	await page.click(
-		'.edit-post-header [aria-label="Add block"], .edit-site-header [aria-label="Add block"]'
+		'.edit-post-header-toolbar__inserter-toggle'
 	);
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #324, #302.

- WP phpunit test library now requires `yoast/phpunit-polyfills` per https://core.trac.wordpress.org/changeset/51559/
- wp-dev-lib won't use local packages added through Composer unless the `composer` task is set to run https://github.com/xwp/wp-dev-lib/blob/a62ccca94f9995f294e12d500c45856adff81e34/scripts/check-diff.sh#L461-L464
- Since we are limiting which wp-dev-lib tasks run during the CI checks through the use of `DEV_LIB_ONLY`, we should always include the `composer` task to ensure the `vendor/bin` gets added to the CI system `PATH` and the local binaries are used instead of the global ones.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/xwp/wp-foo-bar/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/xwp/wp-foo-bar/contributing.md#scripts).
- [x] My code follows the [Contributing Guidelines](https://github.com/xwp/wp-foo-bar/contributing.md) (updates are often made to the guidelines, check it out periodically).
